### PR TITLE
The workaround with the same cookies in a single request

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,11 +46,18 @@ Cookie.prototype.getCookies = function(headers) {
   }
 
   var cookies = [],
+      cookiesObj = {},
       resCookies = headers['set-cookie'] || [];
 
   for (var i = 0; i < resCookies.length; i++) {
-    var cookie = resCookies[i].split(';');
-    cookies.push(cookie[0]);
+    var cookie = resCookies[i].split(';')[0].split('=');
+    cookiesObj[cookie[0]] = cookie[1];
+  }
+
+  for(var prop in cookiesObj) {
+      if(cookiesObj.hasOwnProperty(prop)){
+          cookies.push(prop + '=' + cookiesObj[prop]);
+      }
   }
 
   return cookies.join('; ');


### PR DESCRIPTION
This pull request allows to gracefully handle such kind of bad cookies:
```
  'set-cookie': 
   [ 'AuthCoocies=01021E84D2144557D508FE1E343B82D36FD50801023200300000012F00FF; expires=Fri, 09-Feb-2018 15:40:55 GMT; path=/; HttpOnly',
     'AuthCoocies=01021E84D2144557D508FE1E343B82D36FD508010632003000380033003400360000012F00FF; expires=Fri, 09-Feb-2018 15:40:55 GMT; path=/; HttpOnly' ],
```
  